### PR TITLE
[BUGFIX] US/3 - Włączenie CORS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .venv
+.idea
+__pycache__/

--- a/main.py
+++ b/main.py
@@ -1,8 +1,29 @@
 from fastapi import FastAPI
 from routers import default_router
+from fastapi.middleware.cors import CORSMiddleware
+
+
+origins = [
+    "http://localhost:4200"     # default URL for locally hosted Angular app
+]
 
 app = FastAPI()
+
+# suppresing the warning related to type of the CORSMiddleware,
+# because according to FastAPI devs this code is correct: https://github.com/tiangolo/fastapi/discussions/10968
+
+# noinspection PyTypeChecker
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
 app.include_router(default_router.router)
+
+
 
 if __name__ == '__main__':
     import uvicorn


### PR DESCRIPTION
Aktualnie, aplikacja back-endowa oraz front-end są rozdzielone, przez co domyślnie przeglądarka nie pozwala na komunikację między nimi. Ustawienie na serwerze odpowiednich reguł dla Cross-Origin Resource Sharing pozwala na wysyłanie przez klienta żądań do tego serwera, mimo różnych adresów URL