### PR TITLE
[BUGFIX] Rozwiązanie problemu z nieotrzymywaniem wiadomości przez przeglądarkę z endpointu /game/lobby

### DIFF
--- a/core/game.py
+++ b/core/game.py
@@ -6,6 +6,9 @@ from models.models import User, Poll, Answer, FilledPoll, QuestionTextbox
 from typing import Dict, List
 
 
+import json
+
+
 class Phase(IntEnum):
     REGISTRATION = 1
     POLLING = 2
@@ -57,7 +60,12 @@ class Game:
                     #
                     # yield f"event: lobbyUserListUpdate\ndata: {jsonable_encoder(users)}\n\n"
                     
-                    yield f"data: {jsonable_encoder(users)}\n\n"
+
+                    # jsonable_encoder DOESN'T RETURN JSON STRING, IT TRANSFORMS OBJECT TO DICT WITH VALUES OF JSON-FRIENDLY VALUES!
+                    # (source: https://fastapi.tiangolo.com/tutorial/encoder/)
+                    # That's why we need to wrap the object with json.dumps()!
+
+                    yield f"data: {json.dumps(jsonable_encoder(users))}\n\n"    
                     if await request.is_disconnected():
                         break
 

--- a/core/game.py
+++ b/core/game.py
@@ -49,7 +49,15 @@ class Game:
             try:
                 while True:
                     users = await self.user_update_queue.get()
-                    yield f"event: lobbyUserListUpdate\ndata: {jsonable_encoder(users)}\n\n"
+                    # 
+                    # Please don't use custom values for 'event' field.
+                    # Browsers' EventSource.prototype.onmessage expects to receive messages with "event: message", so any other value will not work.
+                    # This problem isn't reproducible with curl.
+                    # Leaving this field empty, like in register_user() is fine. 
+                    #
+                    # yield f"event: lobbyUserListUpdate\ndata: {jsonable_encoder(users)}\n\n"
+                    
+                    yield f"data: {jsonable_encoder(users)}\n\n"
                     if await request.is_disconnected():
                         break
 

--- a/main.py
+++ b/main.py
@@ -6,7 +6,10 @@ from fastapi.middleware.cors import CORSMiddleware
 import uvicorn
 
 
-origins = ["http://localhost:4200"]  # default URL for locally hosted Angular app
+origins = [
+    "http://localhost:4200",        # teacher's app
+    "http://localhost:4300",        # student's app
+]
 
 app = FastAPI()
 


### PR DESCRIPTION
Do pobierania wiadomości SSE z poziomu przeglądarki, używa się EventSource.
Do stworzonej instancji podpina się handlery 3 eventów: open (inicjalizacja połączenia, zazwyczaj równoczesna z pierwszą otrzymaną od serwera wiadomością), message (tego eventu używamy do wykrywania nowo otrzymanych wiadomości) oraz error. 

![obraz](https://github.com/OilyCannelloni/Software-Engineering-Backend/assets/58552499/2f8c1005-d781-4b29-8894-53b0f7ae4270)

Problem polegał na tym, że przeglądarkowy event "message" nie triggerował się, jeżeli w przesłanej przez serwer wiadomości pole 'event' miało inną wartość niż 'message'.
Ustawienie wartości na 'message' lub po prostu nie modyfikowanie tego pola rozwiązuje problem.